### PR TITLE
:sparkles: 페이지 타이틀 컴포넌트 추가 #24

### DIFF
--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -1,0 +1,5 @@
+export default function createTitle(text, level = 1) {
+  const headingLevel = Math.min(Math.max(level, 1), 6);
+
+  return `<h${headingLevel} class="title">${text}</h${headingLevel}>`;
+}


### PR DESCRIPTION
**[테스트 방법 및 적용 순서]**
1. 대상 페이지에서 `import createTitle from '경로';`
2. const 변수명 = createTitle(_'페이지제목', h태그레벨_); -> string, number
eg. `const absenceTitle = createTitle('부재 등록 및 신청', 1);`
4. html 렌더 위치에 ${변수명} 
eg. `${absenceTitle}`


**[기대결과]**
html 내 정상 렌더링 
![image](https://github.com/user-attachments/assets/638d5415-412c-4cc1-b998-99b48a5c4e67)

`<h1 class="title">부재 등록 및 신청</h1>`
